### PR TITLE
Use esprima instead of esprima-fb

### DIFF
--- a/lib/jsmd/rewriter.js
+++ b/lib/jsmd/rewriter.js
@@ -3,7 +3,7 @@
  */
 
 var Lexer = require('marked').Lexer;
-var parse = require('esprima-fb').parse;
+var parse = require('esprima').parse;
 var replace = require('estraverse').replace;
 var generate = require('escodegen').generate;
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "estraverse": "^1.5.0",
     "escodegen": "^1.3.2",
     "marked": "^0.3.2",
-    "esprima-fb": "*"
+    "esprima": "^2.4.1"
   }
 }

--- a/test/compile/ASI.js
+++ b/test/compile/ASI.js
@@ -1,6 +1,5 @@
 var __jsmd__ = require('assert').deepEqual;
 __jsmd__(1, Math.min(1, 2));
 __jsmd__(2, Math.min(2, 3));
-__jsmd__(3, Math.min(3, 4));
 foo();
 __jsmd__(4, bar());

--- a/test/compile/ASI.md
+++ b/test/compile/ASI.md
@@ -2,9 +2,6 @@
 Math.min(1, 2) // => 1
 Math.min(2, 3) // => 2
 
-Math.min(3, 4)
-
-      // => 3
 foo()
 
 bar() // => 4


### PR DESCRIPTION
This pull request replaces `esprima-fb` with vanilla `esprima`, for two reasons:

1. Facebook is deprecating their fork of `esprima`. See facebook/esprima#111.

2. Installation with esprima-fb fails on newer versions of `npm`, because newer versions of `node-semver` do not interpret the range `"*"` to match prerelease tags. To date, all versions of `esprima-fb` have prerelease tags.

```shellsession
$ npm info --json esprima-fb versions

[
  "1001.1001.1000-dev-harmony-fb",
  "1001.1001.1001-dev-harmony-fb",
  "1001.1001.2000-dev-harmony-fb",
  "2001.1001.0-dev-harmony-fb",
  "2001.1001.2000-dev-harmony-fb",
  "3001.1.0-dev-harmony-fb",
  "4001.1.0-dev-harmony-fb",
  "4001.1001.0-dev-harmony-fb",
  "4001.3001.0-dev-harmony-fb",
  "5001.1.0-dev-harmony-fb",
  "6001.1.0-dev-harmony-fb",
  "6001.1001.0-dev-harmony-fb",
  "7001.1.0-dev-harmony-fb",
  "8001.1.0-dev-harmony-fb",
  "8001.1001.0-dev-harmony-fb",
  "8001.2001.0-dev-harmony-fb",
  "9001.1.0-dev-harmony-fb",
  "10001.1.0-dev-harmony-fb",
  "11001.1.0-dev-harmony-fb",
  "12001.1.0-dev-harmony-fb",
  "13001.1.0-dev-harmony-fb",
  "13001.1001.0-dev-harmony-fb",
  "14001.1.0-dev-harmony-fb",
  "15001.1.0-dev-harmony-fb"
]
$ npm i -g semver
[ node-semver is installed ]
$ semver | grep "^SemVer"
SemVer 5.0.1
$ semver --range '*' `npm info esprima-fb version`
[ Nothing, i.e. no match ]
```

For a build failure in the wild, see https://travis-ci.org/kemitchell/spdx.js/builds/71589150

---

Sincerest thanks for `jsmd`! I am a big fan, and have used it for a number of my packages, including [spdx](https://npmjs.com/packages/spdx), now used by the `npm` CLI.

It's definitely on my to-do list to contribute interop with TAP-generating assertion libraries back to `jsmd` in the future.