### PR TITLE
Quote strings in Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: node_js
+language: "node_js"
 node_js:
-  - 0.8
-  - 0.10
+  - "0.8"
+  - "0.10"
 script:
-  - npm test && npm run-script coveralls
+  - "npm test && npm run-script coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: "node_js"
 node_js:
   - "0.8"
   - "0.10"
+  - "0.11"
+  - "0.12"
+  - "node"
 script:
   - "npm test && npm run-script coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
   - "node"
 script:
   - "npm test && npm run-script coveralls"
+sudo: false


### PR DESCRIPTION
While poking around Travis CI's builds, I noticed a few runs on node "0.1".

Turns out YAML has notice support for floating point, so `- 0.10` gets unhelpfully interpreted as `- 0.1`. Enough folks---including yours truly---make the same mistake that Travis corrects to node@0.10 on the back end.

You might also consider adding `"0.11"`, `"0.12"`, and `"iojs"` for good measure.