### PR TITLE
Use CircleCI instead of Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2.1
+
+build_and_test_steps: &build_and_test_steps
+  steps:
+    - restore_cache:
+        keys:
+          - source-v1-{{ .Branch }}
+          - source-v1-
+    - checkout
+    - save_cache:
+        key: source-v1-{{ .Branch }}
+        paths:
+          - ".git"
+    - run: npm i
+    - run: npm run test
+
+jobs:
+  node4:
+    docker:
+      - image: 'circleci/node:4.9.1'
+    <<: *build_and_test_steps
+  node6:
+    docker:
+      - image: 'circleci/node:6.17.1'
+    <<: *build_and_test_steps
+  node8:
+    docker:
+      - image: 'cimg/node:8.17.0'
+    <<: *build_and_test_steps
+  node16:
+    docker:
+      - image: 'cimg/node:16.13.0'
+    <<: *build_and_test_steps
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - node4
+      - node6
+      - node8
+      - node16

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: "node_js"
-node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "9"
-script:
-  - "npm test && npm run-script coveralls"
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NPM version](https://badge.fury.io/js/jsmd.png)](http://badge.fury.io/js/jsmd)
-[![Build Status](https://secure.travis-ci.org/vesln/jsmd.png)](http://travis-ci.org/vesln/jsmd)
+[![Build Status](https://circleci.com/gh/vesln/jsmd.svg?style=shield)](https://circleci.com/gh/vesln/jsmd)
 [![Coverage Status](https://coveralls.io/repos/vesln/jsmd/badge.png?branch=master)](https://coveralls.io/r/vesln/jsmd?branch=master)
 [![Code Climate](https://codeclimate.com/github/vesln/jsmd.png)](https://codeclimate.com/github/vesln/jsmd)
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/jsmd.js",
   "homepage": "https://github.com/vesln/jsmd",
   "scripts": {
-    "test": "hydro",
+    "test": "_hydro",
     "pretest": "jshint .",
     "coverage": "istanbul cover ./node_modules/hydro/bin/_hydro -- --formatter hydro-silent",
     "coveralls": "istanbul cover ./node_modules/hydro/bin/_hydro --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"


### PR DESCRIPTION
Travis for open source is kinda dead.  Not technically dead, but there's too much friction to reasonably use it.  `travis-ci.org` is no longer building, and to use `travis-ci.com`, you need to [request "open source credits"](https://docs.travis-ci.com/user/billing-faq#sts=What%20if%20I%20am%20building%20open%20source?%20#) each month.  Too much friction.  CircleCI is a solid option.

You'll have to enable `jsmd` in CircleCI for this to work properly.

You can see my build results here:
https://app.circleci.com/pipelines/github/ArtskydJ/jsmd/4/workflows/00529604-d5b7-43b5-a44e-991b51c4c57c