### PR TITLE
Fix Windows tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./lib/jsmd.js",
   "homepage": "https://github.com/vesln/jsmd",
   "scripts": {
-    "test": "hydro",
+    "test": "_hydro",
     "pretest": "jshint .",
     "coverage": "istanbul cover ./node_modules/hydro/bin/_hydro -- --formatter hydro-silent",
     "coveralls": "istanbul cover ./node_modules/hydro/bin/_hydro --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,39 +1,55 @@
 var join = require('path').join;
 var nixt = require('nixt');
 var bin = join(__dirname, '..', 'bin');
+var crossPlatformBase = 'node ./jsmd ';
 
-var app = function() {
+var escapeFixturePath = function(name) {
+  return fixture(name).replace(/\\/g, '\\\\');
+};
+
+var app = function(base) {
   return nixt({ newlines: false })
     .cwd(bin)
-    .base('./jsmd ')
+    .base(base)
     .clone();
 };
 
+test('jsmd is executable', function(done) {
+  if (process.platform !== 'win32') {
+    app('./jsmd ')
+    .stdout(require('../package.json').version)
+    .run('--version')
+    .end(done);
+  } else {
+    done();
+  }
+});
+
 test('--version', function(done) {
-  app()
+  app(crossPlatformBase)
   .stdout(require('../package.json').version)
   .run('--version')
   .end(done);
 });
 
 test('--help', function(done) {
-  app()
+  app(crossPlatformBase)
   .stdout(/Usage: jsmd <path>/)
   .run('--help')
   .end(done);
 });
 
 test('Verification of valid Markdown files', function(done) {
-  app()
+  app(crossPlatformBase)
   .stdout('')
   .code(0)
-  .run(fixture('empty'))
+  .run(escapeFixturePath('empty'))
   .end(done);
 });
 
 test('Verification of bad Markdown files', function(done) {
-  app()
+  app(crossPlatformBase)
   .code(1)
-  .run(fixture('bad'))
+  .run(escapeFixturePath('bad'))
   .end(done);
 });


### PR DESCRIPTION
The CLI tests were failing on Windows for two reasons:
1. You can't run `jsmd.js` on Windows.  It works on macOS/linux because of the hashbang, but not on Windows.
2. The Windows path separator (`\`) needed to be escaped.
